### PR TITLE
Adding feature to allow multiple notifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * Add notifiers array to allow multiple notifiers
   * EmailReporter added
 
 # v2.1.0

--- a/lib/adhearsion/reporter/email_notifier.rb
+++ b/lib/adhearsion/reporter/email_notifier.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require 'pony'
+require 'socket'
 
 module Adhearsion
   class Reporter
@@ -14,7 +15,8 @@ module Adhearsion
       def notify(ex)
         Pony.mail({
           subject: email_subject(ex),
-          body: exception_text(ex)
+          body: exception_text(ex),
+          from: hostname
         })
       end
 
@@ -24,7 +26,7 @@ module Adhearsion
 
     private
       def email_subject(exception)
-        "[#{Adhearsion::Reporter.config.app_name}] Exception: #{exception.class} (#{exception.message})"
+        "[#{Adhearsion::Reporter.config.app_name}-#{environment}] Exception: #{exception.class} (#{exception.message})"
       end
 
       def exception_text(exception)
@@ -32,6 +34,14 @@ module Adhearsion
         "\n\n#{exception.class} (#{exception.message}):\n" +
         exception.backtrace.join("\n") +
         "\n\n"
+      end
+
+      def environment
+        Adhearsion.config.platform.environment.to_s.upcase
+      end
+
+      def hostname
+        Socket.gethostname
       end
     end
   end


### PR DESCRIPTION
Allow an array of notifiers to be specified in place of "notifier." If this notifiers array is non empty, the notifier (singular) will be ignored, and all notifiers in the notifiers array will be registered to handle events.