### PR TITLE
email_notifier: Provide text when exception.backtrace is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # develop
+  * Handle case where exception is passed with no backtrace in EmailReporter
   * Add notifiers array to allow multiple notifiers
   * EmailReporter added
 

--- a/lib/adhearsion/reporter/email_notifier.rb
+++ b/lib/adhearsion/reporter/email_notifier.rb
@@ -30,9 +30,10 @@ module Adhearsion
       end
 
       def exception_text(exception)
+        backtrace = exception.backtrace || ["EMPTY BACKTRACE"]
         "#{Adhearsion::Reporter.config.app_name} reported an exception at #{Time.now.to_s}" +
         "\n\n#{exception.class} (#{exception.message}):\n" +
-        exception.backtrace.join("\n") +
+        backtrace.join("\n") +
         "\n\n"
       end
 


### PR DESCRIPTION
Handle empty backtrace the exception from email_notifier.