### PR TITLE
Allow reporting of custom envs to airbrake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.2
   - jruby-19mode
   - rbx-19mode
   - ruby-head

--- a/lib/adhearsion/reporter.rb
+++ b/lib/adhearsion/reporter.rb
@@ -28,7 +28,7 @@ module Adhearsion
           desc: "Collection of classes that will act as notifiers",
           transform: Proc.new { |v| v.split(',').map { |n| n.to_s.constantize } }
         enable true, desc: "Whether to send notifications - set to false to disable all notifications globally (useful for testing)"
-        environment nil,
+        env nil,
           desc: "Custom environment for error reporting. May be different from the application environment.",
           transform: Proc.new { |v| v.to_sym }
         excluded_environments [:development, :test], desc: "Skip reporting errors for the listed environments (comma delimited when set by environment variable", transform: Proc.new { |v| names = v.split(','); names = names.each.map &:to_sym }

--- a/lib/adhearsion/reporter.rb
+++ b/lib/adhearsion/reporter.rb
@@ -28,6 +28,9 @@ module Adhearsion
           desc: "Collection of classes that will act as notifiers",
           transform: Proc.new { |v| v.split(',').map { |n| n.to_s.constantize } }
         enable true, desc: "Whether to send notifications - set to false to disable all notifications globally (useful for testing)"
+        environment nil,
+          desc: "Custom environment for error reporting. May be different from the application environment.",
+          transform: Proc.new { |v| v.to_sym }
         excluded_environments [:development, :test], desc: "Skip reporting errors for the listed environments (comma delimited when set by environment variable", transform: Proc.new { |v| names = v.split(','); names = names.each.map &:to_sym }
         newrelic {
           license_key 'MYKEY', desc: "Your license key for New Relic"

--- a/lib/adhearsion/reporter/airbrake_notifier.rb
+++ b/lib/adhearsion/reporter/airbrake_notifier.rb
@@ -12,7 +12,7 @@ module Adhearsion
       def init
         @notifier = Toadhopper.new Reporter.config.api_key, :notify_host => Reporter.config.url
         @options = {
-          framework_env: Reporter.config.environment || Adhearsion.config.platform.environment,
+          framework_env: Reporter.config.env || Adhearsion.config.platform.environment,
           notifier_name: 'adhearsion-reporter',
           notifier_version: Adhearsion::Reporter::VERSION,
           project_root: Adhearsion.config.platform[:root],

--- a/lib/adhearsion/reporter/airbrake_notifier.rb
+++ b/lib/adhearsion/reporter/airbrake_notifier.rb
@@ -12,7 +12,7 @@ module Adhearsion
       def init
         @notifier = Toadhopper.new Reporter.config.api_key, :notify_host => Reporter.config.url
         @options = {
-          framework_env: Adhearsion.config.platform.environment,
+          framework_env: Reporter.config.environment || Adhearsion.config.platform.environment,
           notifier_name: 'adhearsion-reporter',
           notifier_version: Adhearsion::Reporter::VERSION,
           project_root: Adhearsion.config.platform[:root],


### PR DESCRIPTION
Adhearsion does not properly support custom environments other than the four hard-coded ones (test, development, staging, production). This means that adhearsion-reporter cannot correctly report the devtbX environment names to Airbrake. In order to avoid having to make complex changes to Adhearsion, we'll simply permit an arbitrary override, `Reporter.config.environment`

Reference:  https://github.com/adhearsion/adhearsion/issues/442